### PR TITLE
test(jmh): anchor JMH gating baselines

### DIFF
--- a/benchmarks/jmh/baselines/main-darwin.json
+++ b/benchmarks/jmh/baselines/main-darwin.json
@@ -1,0 +1,388 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "kt.fluxo.jmh.IncrementIntentBenchmark.fluxo__mvi_handler",
+        "mode" : "thrpt",
+        "threads" : 2,
+        "forks" : 2,
+        "jvm" : "/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.19-10/arm64/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Dfile.encoding=UTF-8",
+            "-Djava.io.tmpdir=/Users/runner/work/fluxo/fluxo/benchmarks/jmh/build/tmp/jmh",
+            "-Duser.country=US",
+            "-Duser.language=en",
+            "-Duser.variant",
+            "-Dkotlinx.coroutines.debug=off"
+        ],
+        "jdkVersion" : "17.0.19",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.19+10",
+        "warmupIterations" : 2,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.3319059664849267,
+            "scoreError" : 0.1848404068109684,
+            "scoreConfidence" : [
+                1.1470655596739583,
+                1.516746373295895
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.096713071398792,
+                "50.0" : 1.3695745153154402,
+                "90.0" : 1.4839897935147965,
+                "95.0" : 1.4906340225855697,
+                "99.0" : 1.4906340225855697,
+                "99.9" : 1.4906340225855697,
+                "99.99" : 1.4906340225855697,
+                "99.999" : 1.4906340225855697,
+                "99.9999" : 1.4906340225855697,
+                "100.0" : 1.4906340225855697
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    1.3667558357125886,
+                    1.096713071398792,
+                    1.1720532650633735,
+                    1.252128486394217,
+                    1.4241917318778383
+                ],
+                [
+                    1.3723931949182915,
+                    1.4906340225855697,
+                    1.3352962630620433,
+                    1.4143147651395422,
+                    1.3945790286970117
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "kt.fluxo.jmh.IncrementIntentBenchmark.fluxo__mvi_reducer",
+        "mode" : "thrpt",
+        "threads" : 2,
+        "forks" : 2,
+        "jvm" : "/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.19-10/arm64/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Dfile.encoding=UTF-8",
+            "-Djava.io.tmpdir=/Users/runner/work/fluxo/fluxo/benchmarks/jmh/build/tmp/jmh",
+            "-Duser.country=US",
+            "-Duser.language=en",
+            "-Duser.variant",
+            "-Dkotlinx.coroutines.debug=off"
+        ],
+        "jdkVersion" : "17.0.19",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.19+10",
+        "warmupIterations" : 2,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4.182682477596814,
+            "scoreError" : 1.4379146593478962,
+            "scoreConfidence" : [
+                2.744767818248918,
+                5.620597136944711
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.0286829921119764,
+                "50.0" : 3.7982109641553006,
+                "90.0" : 5.889717086637413,
+                "95.0" : 5.9363212798028915,
+                "99.0" : 5.9363212798028915,
+                "99.9" : 5.9363212798028915,
+                "99.99" : 5.9363212798028915,
+                "99.999" : 5.9363212798028915,
+                "99.9999" : 5.9363212798028915,
+                "100.0" : 5.9363212798028915
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    5.9363212798028915,
+                    5.470279348148107,
+                    5.035361761297045,
+                    3.6791781429976247,
+                    3.0286829921119764
+                ],
+                [
+                    3.739088746895241,
+                    3.835239446477936,
+                    3.4752793689608614,
+                    3.7611824818326656,
+                    3.8662112074437944
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "kt.fluxo.jmh.IncrementIntentBenchmark.fluxo__mvvmp_intent",
+        "mode" : "thrpt",
+        "threads" : 2,
+        "forks" : 2,
+        "jvm" : "/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.19-10/arm64/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Dfile.encoding=UTF-8",
+            "-Djava.io.tmpdir=/Users/runner/work/fluxo/fluxo/benchmarks/jmh/build/tmp/jmh",
+            "-Duser.country=US",
+            "-Duser.language=en",
+            "-Duser.variant",
+            "-Dkotlinx.coroutines.debug=off"
+        ],
+        "jdkVersion" : "17.0.19",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.19+10",
+        "warmupIterations" : 2,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.5746629512060148,
+            "scoreError" : 0.6580744245143412,
+            "scoreConfidence" : [
+                0.9165885266916737,
+                2.232737375720356
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.1175146208925306,
+                "50.0" : 1.4152867257912103,
+                "90.0" : 2.2378251536942355,
+                "95.0" : 2.24833557341065,
+                "99.0" : 2.24833557341065,
+                "99.9" : 2.24833557341065,
+                "99.99" : 2.24833557341065,
+                "99.999" : 2.24833557341065,
+                "99.9999" : 2.24833557341065,
+                "100.0" : 2.24833557341065
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2.1432313762465043,
+                    2.0991090246687847,
+                    2.24833557341065,
+                    1.626677738532996,
+                    1.2766257876098264
+                ],
+                [
+                    1.1175146208925306,
+                    1.1933601191216934,
+                    1.5253333315131916,
+                    1.2112018199947436,
+                    1.3052401200692287
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "kt.fluxo.jmh.IncrementIntentBenchmark.fluxo__mvi_handler",
+        "mode" : "avgt",
+        "threads" : 2,
+        "forks" : 2,
+        "jvm" : "/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.19-10/arm64/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Dfile.encoding=UTF-8",
+            "-Djava.io.tmpdir=/Users/runner/work/fluxo/fluxo/benchmarks/jmh/build/tmp/jmh",
+            "-Duser.country=US",
+            "-Duser.language=en",
+            "-Duser.variant",
+            "-Dkotlinx.coroutines.debug=off"
+        ],
+        "jdkVersion" : "17.0.19",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.19+10",
+        "warmupIterations" : 2,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.4558863408867986,
+            "scoreError" : 0.2846054911355493,
+            "scoreConfidence" : [
+                1.1712808497512492,
+                1.740491832022348
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.189326261510375,
+                "50.0" : 1.4020616972088789,
+                "90.0" : 1.7862855680694665,
+                "95.0" : 1.7907093086358177,
+                "99.0" : 1.7907093086358177,
+                "99.9" : 1.7907093086358177,
+                "99.99" : 1.7907093086358177,
+                "99.999" : 1.7907093086358177,
+                "99.9999" : 1.7907093086358177,
+                "100.0" : 1.7907093086358177
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.189326261510375,
+                    1.334084731252687,
+                    1.4265217770196,
+                    1.7464719029723055,
+                    1.4475525998430212
+                ],
+                [
+                    1.7907093086358177,
+                    1.3776016173981576,
+                    1.3356483347060895,
+                    1.5420321720568477,
+                    1.3689147034730835
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "kt.fluxo.jmh.IncrementIntentBenchmark.fluxo__mvi_reducer",
+        "mode" : "avgt",
+        "threads" : 2,
+        "forks" : 2,
+        "jvm" : "/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.19-10/arm64/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Dfile.encoding=UTF-8",
+            "-Djava.io.tmpdir=/Users/runner/work/fluxo/fluxo/benchmarks/jmh/build/tmp/jmh",
+            "-Duser.country=US",
+            "-Duser.language=en",
+            "-Duser.variant",
+            "-Dkotlinx.coroutines.debug=off"
+        ],
+        "jdkVersion" : "17.0.19",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.19+10",
+        "warmupIterations" : 2,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.6024104501411928,
+            "scoreError" : 0.10884105863302987,
+            "scoreConfidence" : [
+                0.4935693915081629,
+                0.7112515087742226
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.523566869520848,
+                "50.0" : 0.586226523946118,
+                "90.0" : 0.74953370513394,
+                "95.0" : 0.7551389746345872,
+                "99.0" : 0.7551389746345872,
+                "99.9" : 0.7551389746345872,
+                "99.99" : 0.7551389746345872,
+                "99.999" : 0.7551389746345872,
+                "99.9999" : 0.7551389746345872,
+                "100.0" : 0.7551389746345872
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.523566869520848,
+                    0.6024775725663634,
+                    0.7551389746345872,
+                    0.6990862796281148,
+                    0.5627249265634711
+                ],
+                [
+                    0.5733692769903773,
+                    0.5738154240311014,
+                    0.5999619256146693,
+                    0.53532562800126,
+                    0.5986376238611344
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "kt.fluxo.jmh.IncrementIntentBenchmark.fluxo__mvvmp_intent",
+        "mode" : "avgt",
+        "threads" : 2,
+        "forks" : 2,
+        "jvm" : "/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.19-10/arm64/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Dfile.encoding=UTF-8",
+            "-Djava.io.tmpdir=/Users/runner/work/fluxo/fluxo/benchmarks/jmh/build/tmp/jmh",
+            "-Duser.country=US",
+            "-Duser.language=en",
+            "-Duser.variant",
+            "-Dkotlinx.coroutines.debug=off"
+        ],
+        "jdkVersion" : "17.0.19",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.19+10",
+        "warmupIterations" : 2,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.6531855410179088,
+            "scoreError" : 0.34126505597347523,
+            "scoreConfidence" : [
+                1.3119204850444337,
+                1.994450596991384
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.327142845395171,
+                "50.0" : 1.601726172862318,
+                "90.0" : 2.048538877194602,
+                "95.0" : 2.0572216449041636,
+                "99.0" : 2.0572216449041636,
+                "99.9" : 2.0572216449041636,
+                "99.99" : 2.0572216449041636,
+                "99.999" : 2.0572216449041636,
+                "99.9999" : 2.0572216449041636,
+                "100.0" : 2.0572216449041636
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.540605038871603,
+                    1.5615651359685643,
+                    1.496112422282101,
+                    1.327142845395171,
+                    1.478139777211712
+                ],
+                [
+                    1.9703939678085494,
+                    2.0572216449041636,
+                    1.7176894370436535,
+                    1.6418872097560717,
+                    1.7410979309374999
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/benchmarks/jmh/baselines/main-linux.json
+++ b/benchmarks/jmh/baselines/main-linux.json
@@ -1,0 +1,388 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "kt.fluxo.jmh.IncrementIntentBenchmark.fluxo__mvi_handler",
+        "mode" : "thrpt",
+        "threads" : 2,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/temurin-17-jdk-amd64/bin/java",
+        "jvmArgs" : [
+            "-Dfile.encoding=UTF-8",
+            "-Djava.io.tmpdir=/home/runner/work/fluxo/fluxo/benchmarks/jmh/build/tmp/jmh",
+            "-Duser.country",
+            "-Duser.language=en",
+            "-Duser.variant",
+            "-Dkotlinx.coroutines.debug=off"
+        ],
+        "jdkVersion" : "17.0.19",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.19+10",
+        "warmupIterations" : 2,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.957700700999658,
+            "scoreError" : 0.01990152345784512,
+            "scoreConfidence" : [
+                1.937799177541813,
+                1.977602224457503
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.9394214710571918,
+                "50.0" : 1.953469337072018,
+                "90.0" : 1.9772330560861597,
+                "95.0" : 1.9772584035301723,
+                "99.0" : 1.9772584035301723,
+                "99.9" : 1.9772584035301723,
+                "99.99" : 1.9772584035301723,
+                "99.999" : 1.9772584035301723,
+                "99.9999" : 1.9772584035301723,
+                "100.0" : 1.9772584035301723
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    1.9394214710571918,
+                    1.9516072895450363,
+                    1.9553313845989995,
+                    1.9489482864818082,
+                    1.9448580710445547
+                ],
+                [
+                    1.9772584035301723,
+                    1.977004929090047,
+                    1.9506970461989335,
+                    1.966693562218032,
+                    1.9651865662318038
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "kt.fluxo.jmh.IncrementIntentBenchmark.fluxo__mvi_reducer",
+        "mode" : "thrpt",
+        "threads" : 2,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/temurin-17-jdk-amd64/bin/java",
+        "jvmArgs" : [
+            "-Dfile.encoding=UTF-8",
+            "-Djava.io.tmpdir=/home/runner/work/fluxo/fluxo/benchmarks/jmh/build/tmp/jmh",
+            "-Duser.country",
+            "-Duser.language=en",
+            "-Duser.variant",
+            "-Dkotlinx.coroutines.debug=off"
+        ],
+        "jdkVersion" : "17.0.19",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.19+10",
+        "warmupIterations" : 2,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.2428572365794395,
+            "scoreError" : 0.7506543966197801,
+            "scoreConfidence" : [
+                5.49220283995966,
+                6.993511633199219
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.764896661240462,
+                "50.0" : 6.244302728288518,
+                "90.0" : 6.731328281164317,
+                "95.0" : 6.7322080671724995,
+                "99.0" : 6.7322080671724995,
+                "99.9" : 6.7322080671724995,
+                "99.99" : 6.7322080671724995,
+                "99.999" : 6.7322080671724995,
+                "99.9999" : 6.7322080671724995,
+                "100.0" : 6.7322080671724995
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    6.723410207090672,
+                    6.6930826392756,
+                    6.7322080671724995,
+                    6.717775778315076,
+                    6.702062540002222
+                ],
+                [
+                    5.766507858047503,
+                    5.7955228173014355,
+                    5.764896661240462,
+                    5.765558607193809,
+                    5.76754719015511
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "kt.fluxo.jmh.IncrementIntentBenchmark.fluxo__mvvmp_intent",
+        "mode" : "thrpt",
+        "threads" : 2,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/temurin-17-jdk-amd64/bin/java",
+        "jvmArgs" : [
+            "-Dfile.encoding=UTF-8",
+            "-Djava.io.tmpdir=/home/runner/work/fluxo/fluxo/benchmarks/jmh/build/tmp/jmh",
+            "-Duser.country",
+            "-Duser.language=en",
+            "-Duser.variant",
+            "-Dkotlinx.coroutines.debug=off"
+        ],
+        "jdkVersion" : "17.0.19",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.19+10",
+        "warmupIterations" : 2,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.9217322575281355,
+            "scoreError" : 0.007802757317003407,
+            "scoreConfidence" : [
+                1.913929500211132,
+                1.929535014845139
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.9113407283505985,
+                "50.0" : 1.9226863205193307,
+                "90.0" : 1.9299519211135114,
+                "95.0" : 1.9304469675855842,
+                "99.0" : 1.9304469675855842,
+                "99.9" : 1.9304469675855842,
+                "99.99" : 1.9304469675855842,
+                "99.999" : 1.9304469675855842,
+                "99.9999" : 1.9304469675855842,
+                "100.0" : 1.9304469675855842
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    1.9183248657671983,
+                    1.9113407283505985,
+                    1.9181202053825948,
+                    1.9201157116540832,
+                    1.923012122665024
+                ],
+                [
+                    1.9304469675855842,
+                    1.9223605183736372,
+                    1.923170026886015,
+                    1.9249349257517634,
+                    1.9254965028648574
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "kt.fluxo.jmh.IncrementIntentBenchmark.fluxo__mvi_handler",
+        "mode" : "avgt",
+        "threads" : 2,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/temurin-17-jdk-amd64/bin/java",
+        "jvmArgs" : [
+            "-Dfile.encoding=UTF-8",
+            "-Djava.io.tmpdir=/home/runner/work/fluxo/fluxo/benchmarks/jmh/build/tmp/jmh",
+            "-Duser.country",
+            "-Duser.language=en",
+            "-Duser.variant",
+            "-Dkotlinx.coroutines.debug=off"
+        ],
+        "jdkVersion" : "17.0.19",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.19+10",
+        "warmupIterations" : 2,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.018372970797211,
+            "scoreError" : 0.013627496062566583,
+            "scoreConfidence" : [
+                1.0047454747346443,
+                1.0320004668597775
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0075280720951594,
+                "50.0" : 1.0184571435287604,
+                "90.0" : 1.028369445229714,
+                "95.0" : 1.0284207444040852,
+                "99.0" : 1.0284207444040852,
+                "99.9" : 1.0284207444040852,
+                "99.99" : 1.0284207444040852,
+                "99.999" : 1.0284207444040852,
+                "99.9999" : 1.0284207444040852,
+                "100.0" : 1.0284207444040852
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0284207444040852,
+                    1.0253718203300592,
+                    1.0279077526603753,
+                    1.0275948650303834,
+                    1.0245364824685468
+                ],
+                [
+                    1.0108236801228596,
+                    1.0075280720951594,
+                    1.0085087561505046,
+                    1.0106597301211617,
+                    1.012377804588974
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "kt.fluxo.jmh.IncrementIntentBenchmark.fluxo__mvi_reducer",
+        "mode" : "avgt",
+        "threads" : 2,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/temurin-17-jdk-amd64/bin/java",
+        "jvmArgs" : [
+            "-Dfile.encoding=UTF-8",
+            "-Djava.io.tmpdir=/home/runner/work/fluxo/fluxo/benchmarks/jmh/build/tmp/jmh",
+            "-Duser.country",
+            "-Duser.language=en",
+            "-Duser.variant",
+            "-Dkotlinx.coroutines.debug=off"
+        ],
+        "jdkVersion" : "17.0.19",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.19+10",
+        "warmupIterations" : 2,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.3223600398439488,
+            "scoreError" : 0.01669178148257047,
+            "scoreConfidence" : [
+                0.30566825836137834,
+                0.33905182132651923
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.31072794984615515,
+                "50.0" : 0.322197967540347,
+                "90.0" : 0.3357912556382945,
+                "95.0" : 0.33610824549151785,
+                "99.0" : 0.33610824549151785,
+                "99.9" : 0.33610824549151785,
+                "99.99" : 0.33610824549151785,
+                "99.999" : 0.33610824549151785,
+                "99.9999" : 0.33610824549151785,
+                "100.0" : 0.33610824549151785
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.33610824549151785,
+                    0.33178455737062534,
+                    0.33076438973895134,
+                    0.33202757509488245,
+                    0.3329383469592839
+                ],
+                [
+                    0.3110503124857066,
+                    0.31072794984615515,
+                    0.31289784916627306,
+                    0.31363154534174265,
+                    0.3116696269443502
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "kt.fluxo.jmh.IncrementIntentBenchmark.fluxo__mvvmp_intent",
+        "mode" : "avgt",
+        "threads" : 2,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/temurin-17-jdk-amd64/bin/java",
+        "jvmArgs" : [
+            "-Dfile.encoding=UTF-8",
+            "-Djava.io.tmpdir=/home/runner/work/fluxo/fluxo/benchmarks/jmh/build/tmp/jmh",
+            "-Duser.country",
+            "-Duser.language=en",
+            "-Duser.variant",
+            "-Dkotlinx.coroutines.debug=off"
+        ],
+        "jdkVersion" : "17.0.19",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.19+10",
+        "warmupIterations" : 2,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.8131543501704004,
+            "scoreError" : 0.35587021742342884,
+            "scoreConfidence" : [
+                0.45728413274697155,
+                1.1690245675938291
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.5888250112673151,
+                "50.0" : 0.8117364014322214,
+                "90.0" : 1.0446653853717833,
+                "95.0" : 1.0453413100999605,
+                "99.0" : 1.0453413100999605,
+                "99.9" : 1.0453413100999605,
+                "99.99" : 1.0453413100999605,
+                "99.999" : 1.0453413100999605,
+                "99.9999" : 1.0453413100999605,
+                "100.0" : 1.0453413100999605
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0331810129230365,
+                    1.0453413100999605,
+                    1.0385820628181885,
+                    1.0329187645024511,
+                    1.0321347249369965
+                ],
+                [
+                    0.5888250112673151,
+                    0.5913178014612994,
+                    0.588876749499041,
+                    0.5913380779274462,
+                    0.5890279862682686
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+


### PR DESCRIPTION
## Summary

Host-matched JMH gating baselines produced by [jmh-baseline-bootstrap run 28051847325](https://github.com/fluxo-kt/fluxo/actions/runs/28051847325):

- `benchmarks/jmh/baselines/main-darwin.json` (macos-latest)
- `benchmarks/jmh/baselines/main-linux.json` (ubuntu-latest)

Gating profile: `forks=2, warmupIterations=2, iterations=5, threads=2`. Enables the `JMH_BASELINE_CHECK=1` dual gate in `.github/workflows/benchmark-summary.main.kts` (`|Δ|/σ>2 AND |Δ|/base>5%`). Until merged, the gate logs "no baseline" and exits 0 — safe-by-default.

## Provenance

Triggered against `main` after dev Build CI [run 28049319076](https://github.com/fluxo-kt/fluxo/actions/runs/28049319076) (commit `b38deef`) reached macOS green. Both baseline-producer matrix legs succeeded; the workflow's `gh pr create` step failed because the repo has **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests** disabled. Filing this PR manually closes the loop; future runs will re-fail the PR step unless that toggle is enabled. Optional follow-up: harden the workflow to fail-soft on this exact GraphQL error and print the create URL instead of exiting 1.

## Test plan

- [ ] CI green on this branch
- [ ] Maintainer eyeball the per-benchmark median values in both JSONs for sanity (no zeros, no negative scores, no missing benchmarks)
- [ ] After merge, a deliberate JMH regression (e.g. add `Thread.sleep(1)` to a `fluxo` benchmark) on a follow-up PR triggers the dual gate